### PR TITLE
add document upload options

### DIFF
--- a/config/schema/tmgmt_lilt.schema.yml
+++ b/config/schema/tmgmt_lilt.schema.yml
@@ -13,3 +13,12 @@ tmgmt.translator.settings.lilt:
     lilt_log_api:
       type: boolean
       label: Lilt API logging
+    lilt_pretranslation:
+      type: string
+      label: Lilt Pretranslation
+    lilt_auto_accept:
+      type: boolean
+      label: Lilt Auto-accept
+    lilt_config_id:
+      type: integer
+      label: Lilt Config ID

--- a/src/LiltTranslatorUi.php
+++ b/src/LiltTranslatorUi.php
@@ -66,6 +66,32 @@ class LiltTranslatorUi extends TranslatorPluginUiBase {
       '#description' => t('Enables Watchdog logging of Lilt API requests.'),
       '#required' => FALSE,
     ];
+    $form['lilt_pretranslation'] = [
+      '#type' => 'select',
+      '#title' => t('Lilt Pretranslation'),
+      '#default_value' => $translator->getSetting('lilt_pretranslation'),
+      '#description' => t('The optional pre-translation option to use for uploaded documents.'),
+      '#options' => [
+        '' => t('Null (none)'),
+        'tm' => t('Translation Memory'),
+        'tm+mt' => t('Translation Memory & Machine Translation'),
+      ],
+      '#required' => FALSE,
+    ];
+    $form['lilt_auto_accept'] = [
+      '#type' => 'checkbox',
+      '#title' => t('Lilt Auto-accept'),
+      '#default_value' => $translator->getSetting('lilt_auto_accept') ?: FALSE,
+      '#description' => t('Auto-accept pre-matched translations.'),
+      '#required' => FALSE,
+    ];
+    $form['lilt_config_id'] = [
+      '#type' => 'textfield',
+      '#title' => t('Lilt Config ID'),
+      '#default_value' => $translator->getSetting('lilt_config_id'),
+      '#description' => t('An optional pararameter to specify an import configuration to be applied when extracting translatable content from the document.'),
+      '#required' => FALSE,
+    ];
     $form += parent::addConnectButton();
 
     return $form;

--- a/src/Plugin/tmgmt/Translator/LiltTranslator.php
+++ b/src/Plugin/tmgmt/Translator/LiltTranslator.php
@@ -370,6 +370,14 @@ class LiltTranslator extends TranslatorPluginBase implements ContainerFactoryPlu
       'name' => $file_name,
       'project_id' => $project_id,
     ];
+    $optional_params = ['lilt_pretranslation' => 'pretranslate', 'lilt_auto_accept' => 'auto_accept', 'lilt_config_id' =>
+    'config_id'];
+    foreach ($optional_params as $param => $query) {
+      $param_value = $this->translator->getSetting($param);
+      if (isset($param_value) && $param_value != '') {
+        $params[$query] = $param_value;
+      }
+    }
 
     // Set headers and body for file PUT request.
     $options['headers']['Authorization'] = 'Basic ' . base64_encode($api_key . ':' . $api_key);


### PR DESCRIPTION
Adds 3 options to Lilt document upload processing: Auto-accept, pre translate, & Config ID

- Functional Testing:
  - Nav to `/admin/tmgmt/translators/manage/lilt` and enter in new options
    - [x] Verify options were saved with `drush cget tmgmt.translator.lilt settings`
  - Go through the TMGMT workflow to select documents & submit to Lilt
    - [x] Verify documents were uploaded with the new options set
- Regression Testing:
  - Go through the TMGMT workflow a few time with different documents & configuration options.
    - [x] Verify additional params added to document POST hasn't broken functionality.

Resolves a part of issue 10.
