### PR TITLE
disable use all settings checkbox / disable redirect after batch run

### DIFF
--- a/src/Plugin/tmgmt/Translator/LiltTranslator.php
+++ b/src/Plugin/tmgmt/Translator/LiltTranslator.php
@@ -18,7 +18,6 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use function GuzzleHttp\Psr7\parse_query;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * Lilt translation plugin controller.
@@ -269,9 +268,6 @@ class LiltTranslator extends TranslatorPluginBase implements ContainerFactoryPlu
    *   Results.
    * @param array $operations
    *   Operations.
-   *
-   * @return \Symfony\Component\HttpFoundation\RedirectResponse|false
-   *   Redirects to jobs overview page if success.
    */
   public static function createDocumentForJobItemBatchFinish($success, array $results, array $operations) {
 
@@ -294,8 +290,6 @@ class LiltTranslator extends TranslatorPluginBase implements ContainerFactoryPlu
         '@created' => $created,
         '@job_label' => $job->label(),
       ]));
-      $jobs_list_url = Url::fromRoute('view.tmgmt_job_overview.page_1')->toString();
-      return new RedirectResponse($jobs_list_url);
     }
     // Fail:
     elseif (!empty($created)) {

--- a/tmgmt_lilt.module
+++ b/tmgmt_lilt.module
@@ -207,6 +207,23 @@ function tmgmt_lilt_form_tmgmt_job_item_edit_form_accept_submit(array $form, For
 /**
  * Implements hook_form_FORM_ID_alter().
  */
+function tmgmt_lilt_form_tmgmt_job_edit_form_alter(&$form, $form_state) {
+  /** @var Drupal\tmgmt\Entity\Job $job */
+  $job = $form_state->getFormObject()->getEntity();
+
+  if (!$job->hasTranslator() || !$job->getTranslatorId() == 'lilt') {
+    return;
+  }
+
+  // If we have multiple jobs/target langs, the Lilt TMs can't be the same.
+  if (isset($form['translator_wrapper']['submit_all'])) {
+    unset($form['translator_wrapper']['submit_all']);
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
 function tmgmt_lilt_form_views_exposed_form_alter(&$form, $form_state) {
   $view = $form_state->get('view');
 


### PR DESCRIPTION
2 things:

- Removes **Submit all...** button on the job submission form. 
- Remove URL redirection on batch processing so TMGMT queued multi-job/multi-language workflow can complete without having to navigate back to a job management page.

Functional Testing:
  - Nav to `/admin/tmgmt/sources` 
  - Use the **Checkout** section or **Add to Cart** button (completion via `/admin/tmgmt/cart`) to request multiple translations for a content node
    - [x] Verify the **Submit all...** checkbox is removed when Lilt is used as the provider
  - Use the **Submit to provider and continue** button
     - [x] Verify after batch processing, the user is redirected to complete the other jobs in the other target language
  - Complete submission to Lilt

Regression Testing:
  - Nav to Lilt App
     - [x] Verify the Lilt project have been created with the correct settings.
  - Complete translation in Lilt
  - Complete TMGMT workflow (pull translation, review, etc.)
     - [x] Verify the user can complete the TMGMT job workflow without any issues

Resolves part of #10 
