### PR TITLE
Job Admin Redirect On Pull Translation

### DIFF
--- a/src/LiltTranslatorUi.php
+++ b/src/LiltTranslatorUi.php
@@ -156,10 +156,12 @@ class LiltTranslatorUi extends TranslatorPluginUiBase {
 
     $tm_filter = $job->getTargetLangcode();
     $tm_filter = (strpos($tm_filter, '-') !== FALSE) ? explode('-', $tm_filter)[0] : $tm_filter;
+
+    $default_date = isset($_SESSION['tmgmt_lilt']['last_job_due_date']) ? $_SESSION['tmgmt_lilt']['last_job_due_date'] : DrupalDateTime::createFromTimestamp(time());
     $settings['due_date'] = [
       '#title' => t('Due Date'),
       '#type' => 'datetime',
-      '#default_value' => is_null($job->getSetting('due_date')) ? DrupalDateTime::createFromTimestamp(time()) : $job->getSetting('due_date'),
+      '#default_value' => is_null($job->getSetting('due_date')) ? $default_date : $job->getSetting('due_date'),
       '#description' => t('The date on which the translation job is due.'),
       '#date_date_element' => 'date',
       '#date_time_element' => 'time',

--- a/src/Plugin/tmgmt/Translator/LiltTranslator.php
+++ b/src/Plugin/tmgmt/Translator/LiltTranslator.php
@@ -323,6 +323,11 @@ class LiltTranslator extends TranslatorPluginBase implements ContainerFactoryPlu
    * @throws \Drupal\tmgmt\TMGMTException
    */
   public function createLiltProject(JobInterface $job) {
+    // Remember last submitted job label & due date.
+    $_SESSION['tmgmt_lilt'] = [
+      'last_job_label' => $job->get('label')->value,
+      'last_job_due_date' => $job->getSetting('due_date'),
+    ];
     // Prepare parameters for Project API.
     $name = $job->get('label')->value ?: 'Drupal Lilt project ' . $job->id();
     $params = [

--- a/tmgmt_lilt.module
+++ b/tmgmt_lilt.module
@@ -219,6 +219,17 @@ function tmgmt_lilt_form_tmgmt_job_edit_form_alter(&$form, $form_state) {
   if (isset($form['translator_wrapper']['submit_all'])) {
     unset($form['translator_wrapper']['submit_all']);
   }
+
+  // If job is part of a queue re-use the last used label.
+  $job = $form_state->getFormObject()->getEntity();
+  $job_queue = \Drupal::service('tmgmt.queue');
+  if ($job->isSubmittable() && $job_queue->isJobInQueue($job) && ($job_queue->count() + $job_queue->getProcessed()) > 1) {
+    if (isset($form['label']['widget'][0]['value'])) {
+      $last_label = isset($_SESSION['tmgmt_lilt']['last_job_label']) ? $_SESSION['tmgmt_lilt']['last_job_label'] : '';
+      $label_widget = &$form['label']['widget'][0]['value'];
+      $label_widget['#default_value'] = ($label_widget['#default_value'] == '') ? $last_label : $label_widget['#default_value'];
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
2 things: Ensures a redirect to the jobs admin page on pulling translation. Adds a status message on completed TMGTM jobs in the event of an audit trail follow up.

- Functional Testing
  - Add a new TMGMT job
  - Use the **Pull translations** button
     - [x] Verify user is redirected back to back to job admin page (`/admin/tmgmt/jobs/%`)
  - View any aborted/finished TMGMT jobs (`/admin/tmgmt/jobs?state=5` or `/admin/tmgmt/jobs?state=4`) and view an old job. 
     - [x] Verify provider information status message about the project being archived.

Resolves #15 . 