### PR TITLE
ENG-21981: explicity access check added for cron job function

### DIFF
--- a/tmgmt_lilt.module
+++ b/tmgmt_lilt.module
@@ -247,6 +247,7 @@ function tmgmt_lilt_cron() {
   // Load active translation jobs.
   $job_ids = \Drupal::entityQuery('tmgmt_job')
     ->condition('state', Job::STATE_ACTIVE)
+    ->accessCheck(FALSE)
     ->execute();
 
   if (!empty($job_ids)) {


### PR DESCRIPTION
Fixes: [ENG-21981](https://lilt.atlassian.net/browse/ENG-21981)
add access check to entityQuery

[ENG-21981]: https://lilt.atlassian.net/browse/ENG-21981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ