### PR TITLE
feat(CRT-345): send X-Lilt-Connector-Version header on all Lilt API requests

### DIFF
--- a/src/Plugin/tmgmt/Translator/LiltTranslator.php
+++ b/src/Plugin/tmgmt/Translator/LiltTranslator.php
@@ -71,8 +71,6 @@ class LiltTranslator extends TranslatorPluginBase implements ContainerFactoryPlu
    *
    * Sent as the `X-Lilt-Connector-Version` header on every outbound request.
    * Must be semver (MAJOR.MINOR.PATCH) — the connectors API expects that form.
-   * Derived from the Drupal package release tag, dropping the `8.x-` core
-   * compatibility prefix: tag `8.x-1.6` -> `1.6.0`. Bump on each release.
    */
   const CONNECTOR_VERSION = '1.6.0';
 

--- a/src/Plugin/tmgmt/Translator/LiltTranslator.php
+++ b/src/Plugin/tmgmt/Translator/LiltTranslator.php
@@ -67,6 +67,16 @@ const SPECIAL_LANG_CODES = [
 class LiltTranslator extends TranslatorPluginBase implements ContainerFactoryPluginInterface, ContinuousTranslatorInterface {
 
   /**
+   * Connector version reported to the Lilt API.
+   *
+   * Sent as the `X-Lilt-Connector-Version` header on every outbound request.
+   * Must be semver (MAJOR.MINOR.PATCH) — the connectors API expects that form.
+   * Derived from the Drupal package release tag, dropping the `8.x-` core
+   * compatibility prefix: tag `8.x-1.6` -> `1.6.0`. Bump on each release.
+   */
+  const CONNECTOR_VERSION = '1.6.0';
+
+  /**
    * Guzzle HTTP client.
    *
    * @var \GuzzleHttp\ClientInterface
@@ -422,6 +432,7 @@ class LiltTranslator extends TranslatorPluginBase implements ContainerFactoryPlu
     $options['headers']['Authorization'] = 'Basic ' . base64_encode($api_key . ':' . $api_key);
     $options['headers']['Content-Type'] = 'application/octet-stream';
     $options['headers']['LILT-API'] = json_encode($params);
+    $options['headers']['X-Lilt-Connector-Version'] = 'drupal/' . self::CONNECTOR_VERSION;
     $options['body'] = $xliff;
 
     // We don't need apiRequest here just common request.
@@ -957,6 +968,7 @@ class LiltTranslator extends TranslatorPluginBase implements ContainerFactoryPlu
       $options['headers'] = [
         'Content-Type' => 'application/json',
         'Authorization' => 'Basic ' . base64_encode($api_key . ':' . $api_key),
+        'X-Lilt-Connector-Version' => 'drupal/' . self::CONNECTOR_VERSION,
       ];
     }
 

--- a/tests/src/Unit/LiltTranslatorConnectorVersionTest.php
+++ b/tests/src/Unit/LiltTranslatorConnectorVersionTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace Drupal\Tests\tmgmt_lilt\Unit;
+
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drupal\tmgmt_lilt\Plugin\tmgmt\Translator\LiltTranslator;
+use Drupal\tmgmt\TranslatorInterface;
+use Drupal\Tests\UnitTestCase;
+use GuzzleHttp\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Verifies the X-Lilt-Connector-Version header on outbound Lilt API requests.
+ *
+ * @coversDefaultClass \Drupal\tmgmt_lilt\Plugin\tmgmt\Translator\LiltTranslator
+ *
+ * @group tmgmt_lilt
+ */
+class LiltTranslatorConnectorVersionTest extends UnitTestCase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Provide a minimal container so any \Drupal::logger() call is harmless.
+    $container = new \Symfony\Component\DependencyInjection\Container();
+    $logger = $this->createMock(LoggerInterface::class);
+    $loggerFactory = $this->createMock(LoggerChannelFactoryInterface::class);
+    $loggerFactory->method('get')->willReturn($logger);
+    $container->set('logger.factory', $loggerFactory);
+    \Drupal::setContainer($container);
+  }
+
+  /**
+   * Builds a translator mock returning the given settings.
+   *
+   * @param array $settings
+   *   Keyed settings returned by getSetting().
+   *
+   * @return \Drupal\tmgmt\TranslatorInterface
+   *   The translator mock.
+   */
+  protected function mockTranslator(array $settings): TranslatorInterface {
+    $translator = $this->getMockBuilder(TranslatorInterface::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $translator->method('getSetting')
+      ->willReturnCallback(function ($key) use ($settings) {
+        return $settings[$key] ?? '';
+      });
+    return $translator;
+  }
+
+  /**
+   * Builds a 200 response whose body returns the given contents.
+   *
+   * @param string $contents
+   *   The response body contents.
+   *
+   * @return \Psr\Http\Message\ResponseInterface
+   *   The response mock.
+   */
+  protected function mockResponse(string $contents): ResponseInterface {
+    $stream = $this->createMock(StreamInterface::class);
+    // request() reads the body via getContents(); createLiltRemoteFile() casts
+    // the stream to a string, so stub both.
+    $stream->method('getContents')->willReturn($contents);
+    $stream->method('__toString')->willReturn($contents);
+    $response = $this->createMock(ResponseInterface::class);
+    $response->method('getStatusCode')->willReturn(200);
+    $response->method('getBody')->willReturn($stream);
+    return $response;
+  }
+
+  /**
+   * Matches a Guzzle options array carrying the connector version header.
+   *
+   * @return \PHPUnit\Framework\Constraint\Callback
+   *   The constraint.
+   */
+  protected function hasConnectorVersionHeader() {
+    return $this->callback(function ($options) {
+      return isset($options['headers']['X-Lilt-Connector-Version'])
+        && $options['headers']['X-Lilt-Connector-Version'] === 'drupal/' . LiltTranslator::CONNECTOR_VERSION;
+    });
+  }
+
+  /**
+   * Requests routed through request() carry the connector version header.
+   *
+   * @covers ::request
+   */
+  public function testApiRequestSendsConnectorVersionHeader() {
+    $client = $this->getMockBuilder(ClientInterface::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $client->expects($this->once())
+      ->method('request')
+      ->with(
+        $this->equalTo('GET'),
+        $this->anything(),
+        $this->hasConnectorVersionHeader()
+      )
+      ->willReturn($this->mockResponse('{}'));
+
+    $translator = $this->mockTranslator([
+      'lilt_service_url' => 'https://api.example.com',
+      'lilt_api_key' => 'test-key',
+      'lilt_log_api' => FALSE,
+    ]);
+
+    $plugin = new LiltTranslator($client, [], 'lilt', []);
+    $plugin->setTranslator($translator);
+
+    // getServiceRoot() funnels through sendApiRequest() -> request().
+    $plugin->getServiceRoot();
+  }
+
+  /**
+   * The file upload path carries the connector version header.
+   *
+   * @covers ::createLiltRemoteFile
+   */
+  public function testFileUploadSendsConnectorVersionHeader() {
+    $client = $this->getMockBuilder(ClientInterface::class)
+      ->disableOriginalConstructor()
+      ->getMock();
+    $client->expects($this->once())
+      ->method('request')
+      ->with(
+        $this->equalTo('POST'),
+        $this->stringContains('/documents/files'),
+        $this->hasConnectorVersionHeader()
+      )
+      ->willReturn($this->mockResponse('{"id":"doc-123"}'));
+
+    $translator = $this->mockTranslator([
+      'lilt_service_url' => 'https://api.example.com',
+      'lilt_api_key' => 'test-key',
+    ]);
+
+    $plugin = new LiltTranslator($client, [], 'lilt', []);
+    $plugin->setTranslator($translator);
+
+    $document_id = $plugin->createLiltRemoteFile('<xliff/>', 'file', 1);
+    $this->assertSame('doc-123', $document_id);
+  }
+
+}


### PR DESCRIPTION
## What

Adds the `X-Lilt-Connector-Version` header to **every** outbound Lilt API request from the TMGMT Lilt provider, so the connectors backend (CRT-187 ingestion → `ConnectorsVersions` table) can track which Drupal connector version is in use.

Header value: `drupal/{version}`, e.g. `drupal/1.6.0`.

## Changes

- `LiltTranslator`: new `const CONNECTOR_VERSION` (semver). The connectors API expects `{platform}/{semver}`; the Drupal release tag `8.x-1.6` drops its `8.x-` core-compat prefix → `1.6.0`. Bump per release.
- Header added at both outbound HTTP sites:
  - `request()` — chokepoint for all API calls via `sendApiRequest()` (projects, documents, languages, memories, service root).
  - `createLiltRemoteFile()` — XLIFF file upload, which builds its own headers and bypasses `request()`.

## Test plan

- New unit test `LiltTranslatorConnectorVersionTest` asserts the header on both the API-request and file-upload paths.
- `phpunit` unit suite green (25 assertions); `php -l` clean.
- Runtime: enabling the translator "Log API" setting shows `"X-Lilt-Connector-Version":"drupal\/1.6.0"` in submitted-job logs.

Linear: [CRT-345](https://linear.app/lilt-ai/issue/CRT-345/drupal-tmgmt-lilt-provider-x-lilt-connector-version-on-all-api)